### PR TITLE
Change GitHub POST function to take commit hash as parameter

### DIFF
--- a/vars/lambdaTests.groovy
+++ b/vars/lambdaTests.groovy
@@ -31,7 +31,7 @@ def call(Map config) {
                 }
                 steps {
                     script {
-                        tdr.reportStartOfBuildToGitHub(repo)
+                        tdr.reportStartOfBuildToGitHub(repo, env.GIT_COMMIT)
                         tdr.assembleAndStash(config.libraryName)
                     }
                 }
@@ -77,12 +77,12 @@ def call(Map config) {
         post {
             failure {
                 script {
-                    tdr.reportFailedBuildToGitHub(repo)
+                    tdr.reportFailedBuildToGitHub(repo, env.GIT_COMMIT)
                 }
             }
             success {
                 script {
-                    tdr.reportSuccessfulBuildToGitHub(repo)
+                    tdr.reportSuccessfulBuildToGitHub(repo, env.GIT_COMMIT)
                 }
             }
         }

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -26,23 +26,23 @@ def runGitSecrets(repo) {
 //It is important for TDR devs to know that the code they want to merge doesn't break TDR. By sending the build status for every commit (all branches) to GitHub we can ensure code that breaks TDR cannot be merged.
 
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
-def reportStartOfBuildToGitHub(String repo) {
+def reportStartOfBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
+    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
-def reportSuccessfulBuildToGitHub(String repo) {
+def reportSuccessfulBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
+    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
-def reportFailedBuildToGitHub(String repo) {
+def reportFailedBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
+    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
@@ -83,12 +83,11 @@ def createGitHubPullRequest(Map params) {
 }
 
 // This is used to get the URL needed to send a POST request to the GitHub API to update the specified repo with the Jenkins build status. This returns the API URL.
-def githubApiStatusUrl(String repo) {
+def githubApiStatusUrl(String repo, String sha) {
   String cmd = "git rev-parse HEAD"
   if(sh(script: cmd, returnStatus: true) == 128) {
     checkout scm
   }
-  String sha = sh(script: cmd, returnStdout: true).trim()
   String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
   return url
 }

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -26,23 +26,42 @@ def runGitSecrets(repo) {
 //It is important for TDR devs to know that the code they want to merge doesn't break TDR. By sending the build status for every commit (all branches) to GitHub we can ensure code that breaks TDR cannot be merged.
 
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
-def reportStartOfBuildToGitHub(String repo, String sha) {
-  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
+def reportStartOfBuildToGitHub(String repo, String sha='null') {
+  if (sha != 'null') {
+    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+      sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
+    }
+  } else {
+    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+      sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
+    }
   }
 }
 
+
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
-def reportSuccessfulBuildToGitHub(String repo, String sha) {
-  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
+def reportSuccessfulBuildToGitHub(String repo, String sha='null') {
+  if (sha != 'null') {
+    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+      sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
+    }
+  } else {
+    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+      sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
+    }
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
-def reportFailedBuildToGitHub(String repo, String sha) {
-  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
+def reportFailedBuildToGitHub(String repo, String sha='null') {
+  if (sha != 'null') {
+    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+      sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
+    }
+  } else {
+    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+      sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
+    }
   }
 }
 
@@ -83,13 +102,18 @@ def createGitHubPullRequest(Map params) {
 }
 
 // This is used to get the URL needed to send a POST request to the GitHub API to update the specified repo with the Jenkins build status. This returns the API URL.
-def githubApiStatusUrl(String repo, String sha) {
-  String cmd = "git rev-parse HEAD"
-  if(sh(script: cmd, returnStatus: true) == 128) {
-    checkout scm
+def githubApiStatusUrl(String repo, String sha='null') {
+  if (sha != 'null') {
+    String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
+    return url
+  } else {
+    String cmd = "git rev-parse HEAD"
+    if(sh(script: cmd, returnStatus: true) == 128) {
+      checkout scm
+    }
+    String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
+    return url
   }
-  String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
-  return url
 }
 
 def postToDaTdrSlackChannel(Map params) {

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -27,41 +27,23 @@ def runGitSecrets(repo) {
 
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
 def reportStartOfBuildToGitHub(String repo, String sha='null') {
-  if (sha != 'null') {
-    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-      sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
-    }
-  } else {
-    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-      sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
-    }
+  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
 
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
-def reportSuccessfulBuildToGitHub(String repo, String sha='null') {
-  if (sha != 'null') {
-    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-      sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
-    }
-  } else {
-    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-      sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
-    }
+def reportSuccessfulBuildToGitHub(String repo, String sha=null) {
+  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
-def reportFailedBuildToGitHub(String repo, String sha='null') {
-  if (sha != 'null') {
-    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-      sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
-    }
-  } else {
-    withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-      sh "curl -XPOST '${githubApiStatusUrl(repo)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
-    }
+def reportFailedBuildToGitHub(String repo, String sha=null) {
+  withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
+    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
@@ -102,8 +84,8 @@ def createGitHubPullRequest(Map params) {
 }
 
 // This is used to get the URL needed to send a POST request to the GitHub API to update the specified repo with the Jenkins build status. This returns the API URL.
-def githubApiStatusUrl(String repo, String sha='null') {
-  if (sha != 'null') {
+def githubApiStatusUrl(String repo, String sha=null) {
+  if (sha != null) {
     String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
     return url
   } else {


### PR DESCRIPTION
The original `git rev-parse HEAD` method of getting access to latest commit hash was having issues with consistently getting the most recent commit hash. This has now been changed to access the commit hash using Jenkins environment variables, which are available in the main pipeline and the post actions. 