### PR TITLE
Fix Jenkinslib functions when commit sha not provided.

### DIFF
--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -26,7 +26,7 @@ def runGitSecrets(repo) {
 //It is important for TDR devs to know that the code they want to merge doesn't break TDR. By sending the build status for every commit (all branches) to GitHub we can ensure code that breaks TDR cannot be merged.
 
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
-def reportStartOfBuildToGitHub(String repo, String sha='null') {
+def reportStartOfBuildToGitHub(String repo, String sha='UNKNOWN_SHA') {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
     sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
   }
@@ -34,14 +34,14 @@ def reportStartOfBuildToGitHub(String repo, String sha='null') {
 
 
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
-def reportSuccessfulBuildToGitHub(String repo, String sha=null) {
+def reportSuccessfulBuildToGitHub(String repo, String sha='UNKNOWN_SHA') {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
     sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
-def reportFailedBuildToGitHub(String repo, String sha=null) {
+def reportFailedBuildToGitHub(String repo, String sha='UNKNOWN_SHA') {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
     sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
   }
@@ -84,8 +84,8 @@ def createGitHubPullRequest(Map params) {
 }
 
 // This is used to get the URL needed to send a POST request to the GitHub API to update the specified repo with the Jenkins build status. This returns the API URL.
-def githubApiStatusUrl(String repo, String sha=null) {
-  if (sha != null) {
+def githubApiStatusUrl(String repo, String sha='UNKNOWN_SHA') {
+  if (sha != 'UNKNOWN_SHA') {
     String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
     return url
   } else {

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -93,7 +93,8 @@ def githubApiStatusUrl(String repo, String sha='UNKNOWN_SHA') {
     if(sh(script: cmd, returnStatus: true) == 128) {
       checkout scm
     }
-    String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${sha}"
+    String commitSHA = sh(script: cmd, returnStdout: true).trim()
+    String url = "https://api.github.com/repos/nationalarchives/${repo}/statuses/${commitSHA}"
     return url
   }
 }


### PR DESCRIPTION
This fixes the function which creates the correct GitHub API when no commit hash is provided. A line was removed by mistake meaning it used the null valued default parameter even when meeting conditions to find the commit hash. This has now been rectified. 

The `null` valued default parameters have also been changed to a string 'UNKNOWN_SHA' to make potential future debugging easier.