### PR TITLE
Get deploy job name from parameters.

### DIFF
--- a/vars/lambdaTests.groovy
+++ b/vars/lambdaTests.groovy
@@ -62,7 +62,7 @@ def call(Map config) {
 
                                 tdr.pushGitHubBranch("master")
                                 build(
-                                        job: "TDR ${config.libraryName.split("\\s+").collect { it.toLowerCase().capitalize()}} Lambda Deploy",
+                                        job: config.deployJobName,
                                         parameters: [
                                                 string(name: "STAGE", value: "intg"),
                                                 string(name: "TO_DEPLOY", value: versionTag)


### PR DESCRIPTION
Trying to calculate the deploy job name from the library name is
possible but flaky and forces us to name jenkins jobs to match library
jobs which is odd.