### PR TITLE
Update release branch when deploying a Lambda function 

### DIFF
--- a/vars/deployToLambda.groovy
+++ b/vars/deployToLambda.groovy
@@ -23,6 +23,18 @@ def call(Map config) {
           }
         }
       }
+      stage("Update release branch") {
+        steps {
+          script {
+            def releaseBranch = "release-${config.stage}"
+
+            sh "git branch -f ${releaseBranch} HEAD"
+            sshagent(['github-jenkins']) {
+              sh("git push -f origin ${releaseBranch}")
+            }
+          }
+        }
+      }
     }
     post {
       success {

--- a/vars/deployToLambda.groovy
+++ b/vars/deployToLambda.groovy
@@ -1,35 +1,35 @@
 def call(Map config) {
-    library("tdr-jenkinslib")
-    pipeline {
-        agent {
-            label "master"
-        }
-        parameters {
-            choice(name: "STAGE", choices: ["intg", "staging", "prod"], description: "The stage you are deploying the lambda for")
-            string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. '1'")
-        }
-        stages {
-            stage("Deploy lambda") {
-                agent {
-                    ecs {
-                        inheritFrom "aws"
-                        taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRole${config.stage.capitalize()}"
-                    }
-                }
-                steps {
-                    script {
-                        def accountNumber = tdr.getAccountNumberFromStage(config.stage)
-                        sh "python3 /deploy_lambda_from_s3.py ${accountNumber} ${config.stage} tdr-${config.libraryName}-${config.stage} tdr-backend-code-mgmt ${config.version}/${config.deploymentPackageName}"
-                    }
-                }
-            }
-        }
-        post {
-            success {
-                script {
-                    tdr.runEndToEndTests(0, config.stage, BUILD_URL)
-                }
-            }
-        }
+  library("tdr-jenkinslib")
+  pipeline {
+    agent {
+      label "master"
     }
+    parameters {
+      choice(name: "STAGE", choices: ["intg", "staging", "prod"], description: "The stage you are deploying the lambda for")
+      string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. '1'")
+    }
+    stages {
+      stage("Deploy lambda") {
+        agent {
+          ecs {
+            inheritFrom "aws"
+            taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRole${config.stage.capitalize()}"
+          }
+        }
+        steps {
+          script {
+            def accountNumber = tdr.getAccountNumberFromStage(config.stage)
+            sh "python3 /deploy_lambda_from_s3.py ${accountNumber} ${config.stage} tdr-${config.libraryName}-${config.stage} tdr-backend-code-mgmt ${config.version}/${config.deploymentPackageName}"
+          }
+        }
+      }
+    }
+    post {
+      success {
+        script {
+          tdr.runEndToEndTests(0, config.stage, BUILD_URL)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Push the environment-specific release branch to GitHub after running a Lambda deployment. This makes it easier for us to tell which version is running on which environment.

The first commit fixes the indentation, so this PR is probably easier to review commit-by-commit.