### PR TITLE
Change post step to use 'cleanup'

### DIFF
--- a/vars/terraformDeployJob.groovy
+++ b/vars/terraformDeployJob.groovy
@@ -91,7 +91,7 @@ def call(Map config) {
       }
     }
     post {
-      always {
+      cleanup {
         echo 'Deleting Jenkins workspace...'
         deleteDir()
       }


### PR DESCRIPTION
Use 'cleanup' instead of 'always' in post step as deleting directory before end to end tests are triggered causes an error.

The end to end test function is deleted before it is run