### PR TITLE
Change ecr login command

### DIFF
--- a/vars/ecsDeployJob.groovy
+++ b/vars/ecsDeployJob.groovy
@@ -17,7 +17,7 @@ def call(Map config) {
         steps {
           script {
             def image = "${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com/${config.imageName}"
-            sh "aws ecr get-login --region eu-west-2 --no-include-email | bash"
+            sh "aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com"
             sh "docker pull ${image}:${config.toDeploy}"
             sh "docker tag ${image}:${config.toDeploy} ${image}:${config.stage}"
             sh "docker push ${image}:${config.stage}"


### PR DESCRIPTION
Command changed to prevent warning: Using --password via the CLI is insecure. Use --password-stdin.