### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TDR Jenkins has been configured to use the library functions with [Docker](https
 
 ## Available functions
 
-| File | Function | Parameters | Description | Result | 
+| File | Function | Parameters | Description | Result |
 |---|---|---|---|---|
 | ecsDeployJob | call | *config map*: imageName, toDeploy, stage, ecsService, testDelaySecond | Standard TDR Jenkins pipeline job for ECS deployments. Called by client Jenkins jobs | No output, deploys to ECS |
 | sbtReleaseDeployJob | call | *config map*: libraryName, buildNumber, repo| Standard TDR Jenkins pipeline job for sbt library release and deployment. Called by client Jenkins jobs | No output. Publishes updated sbt library to S3 |
@@ -28,7 +28,7 @@ TDR Jenkins has been configured to use the library functions with [Docker](https
 ## Testing functions on Jenkins
 
 1. Create a branch with the new function(s) on in the tdr-jenkinslib repo;
-2. In the Jenkins file that calls the new function(s) add the branch import directly: `@Library("tdr-jenkinslib@[name of branch]") _` 
+2. In the Jenkins file that calls the new function(s) add the branch import directly: `@Library("tdr-jenkinslib@[name of branch]") _`
 3. Create a test multi-branch pipeline job in Jenkins
 4. In the pipeline config add the library config to the Pipeline Libraries. Set the default to the name of the branch with the function(s) to test.
 5. When you replay a branch on the pipeline, all the code from the Jenkins file AND the library is available for editing

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ TDR Jenkins has been configured to use the library functions with [Docker](https
 
 1. Create a branch with the new function(s) on in the tdr-jenkinslib repo;
 2. In the Jenkins file that calls the new function(s) add the branch import directly: `@Library("tdr-jenkinslib@name-of-branch") _`
-3. Create a test multi-branch pipeline job in Jenkins
-4. In the pipeline config add the library config to the Pipeline Libraries. Set the default to the name of the branch with the function(s) to test.
+3. Create a test pipeline job in Jenkins
+4. If the project is a multibranch pipeline, in the pipeline config add the library config to the Pipeline Libraries. Set the default to the name of the branch with the function(s) to test.
 5. When you replay a branch on the pipeline, all the code from the Jenkins file AND the library is available for editing
+
+If the job is a regular pipeline job rather than a multibranch pipeline, you can still test the Jenkinslib branch with `@Library("tdr-jenkinslib@name-of-branch") _`, but you cannot edit the library when replaying the build. You will have to make changes on the Jenkinslib branch and push them. Alternatively, you can create a multibranch pipeline job just for test purposes, but you should add a "Filter by name" filter in the Branch Sources section of the Jenkins job config so that the job only builds your branch.
 
 ## Useful documentation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ TDR Jenkins has been configured to use the library functions with [Docker](https
 ## Testing functions on Jenkins
 
 1. Create a branch with the new function(s) on in the tdr-jenkinslib repo;
-2. In the Jenkins file that calls the new function(s) add the branch import directly: `@Library("tdr-jenkinslib@[name of branch]") _`
+2. In the Jenkins file that calls the new function(s) add the branch import directly: `@Library("tdr-jenkinslib@name-of-branch") _`
 3. Create a test multi-branch pipeline job in Jenkins
 4. In the pipeline config add the library config to the Pipeline Libraries. Set the default to the name of the branch with the function(s) to test.
 5. When you replay a branch on the pipeline, all the code from the Jenkins file AND the library is available for editing


### PR DESCRIPTION
Remove line from Readme about editing a Jenkinslib with replay. This no longer seems to be available. It might not be possible now that we've removed Jenkinslib implicit loading, but that's just a guess: nationalarchives/tdr-jenkins#70

Make Jenkinslib test branch instructions clearer. Remove square brackets that shouldn't be included in the real code. There are so many symbols on that line that _are_ necessary (like the at symbols and the underscore) that it's not obvious that the brackets should be removed.