### PR TITLE
Remove agents from ECS deployment stages to fix Jenkins deadlocks

### DIFF
--- a/vars/ecsDeployJob.groovy
+++ b/vars/ecsDeployJob.groovy
@@ -11,9 +11,6 @@ def call(Map config) {
     }
     stages {
       stage("Docker") {
-        agent {
-          label "master"
-        }
         steps {
           script {
             def image = "${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com/${config.imageName}"
@@ -43,9 +40,6 @@ def call(Map config) {
         }
       }
       stage("Update release branch") {
-        agent {
-          label "master"
-        }
         steps {
           script {
             def releaseBranch = "release-${config.stage}"


### PR DESCRIPTION
Remove agents from stages in the ECS deployment job when the stage agent is the same as the default agent.

The duplicate agent was causing deadlocks during Jenkins deployments because it means the build has to wait for a second executor to become available on the master node, while blocking the first executor. This means that if multiple ECS deployment jobs start at around the same time, they can all get blocked waiting for executors, but none ever become free.

This change should mean that the job only uses one master executor per deployment, so the deadlock never happens.