### PR TITLE
Skip Docker cache when building images

### DIFF
--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -87,7 +87,7 @@ def createGitHubPullRequest(Map params) {
 def buildAndPushImage(String imageName, String stage) {
   def imageTag = "${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com/${imageName}:${stage}"
   sh "aws ecr get-login --region eu-west-2 --no-include-email | bash"
-  sh "docker build -t ${imageTag} ."
+  sh "docker build --no-cache -t ${imageTag} ."
   sh "docker push ${imageTag}"
 }
 


### PR DESCRIPTION
This may slow down build times, but it means that every layer of a Docker image is built when we deploy a new image. This is particularly critical for the steps which install packages, because it means we get the latest available version of the package.