### PR TITLE
Pull latest base image when building Docker image

### DIFF
--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -87,7 +87,7 @@ def createGitHubPullRequest(Map params) {
 def buildAndPushImage(String imageName, String stage) {
   def imageTag = "${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com/${imageName}:${stage}"
   sh "aws ecr get-login --region eu-west-2 --no-include-email | bash"
-  sh "docker build --no-cache -t ${imageTag} ."
+  sh "docker build --pull --no-cache -t ${imageTag} ."
   sh "docker push ${imageTag}"
 }
 


### PR DESCRIPTION
Add `--pull` flag to `docker build` command in function for deploying a Docker image to ECR.

This means that if a base image has been updated, it will be fetched from Docker Hub rather than using any internal cache.

I thought that the `--no-cache` flag (which was added in #39) did this, but it skips the cache for the locally-built layers, _not_ the ones pulled from Docker Hub.