### PR TITLE
Copy library straight from target directory to S3

### DIFF
--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -53,8 +53,7 @@ def assembleAndStash(String libraryName) {
 }
 
 def copyToS3CodeBucket(String libraryName, String versionTag) {
-  sh "cp target/${scalaVersion}/${libraryName}.jar /"
-  sh "aws s3 cp /${libraryName}.jar s3://tdr-backend-code-mgmt/${versionTag}/${libraryName}.jar"
+  sh "aws s3 cp target/${scalaVersion}/${libraryName}.jar s3://tdr-backend-code-mgmt/${versionTag}/${libraryName}.jar"
 }
 
 def getAccountNumberFromStage(String stage) {


### PR DESCRIPTION
Remove intermediate step where the library is copied from the Scala target directory to the root directory. Copying to the root directory doesn't work any more because the Jenkins nodes now run as the jenkins user rather than the root user, and the jenkins user doesn't have permission to copy files to the root directory.