### PR TITLE
Remove the hard coded version from the task.

### DIFF
--- a/vars/sbtReleaseDeployJob.groovy
+++ b/vars/sbtReleaseDeployJob.groovy
@@ -22,7 +22,7 @@ def call(Map config) {
         agent {
           ecs {
             inheritFrom "base"
-            taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish:2"
+            taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish"
           }
         }
         stages {


### PR DESCRIPTION
If the version is omitted, you get the latest which is what we want.
