### PR TITLE
Wrap the release with-defaults call in GITHUB_TOKEN

### DIFF
--- a/vars/sbtReleaseDeployJob.groovy
+++ b/vars/sbtReleaseDeployJob.groovy
@@ -44,7 +44,9 @@ def call(Map config) {
             steps {
               //Commits to origin branch
               sshagent(['github-jenkins']) {
-                sh "sbt +'release with-defaults'"
+                withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_TOKEN')]) {
+                  sh "sbt +'release with-defaults'"
+                }
               }
               script {
                 tdr.postToDaTdrSlackChannel(colour: "good",


### PR DESCRIPTION
One of the repos that calls this is releasing to github and needs the github token to do this.
