### PR TITLE
Fix typo in Jenkinsfile jenkinslib function call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   post {
     failure {
       script {
-        tdr.reportFailedBuiltToGitHub(repo, env.GIT_COMMIT)
+        tdr.reportFailedBuildToGitHub(repo, env.GIT_COMMIT)
       }
     }
     success {


### PR DESCRIPTION
This change fixes a typo in a function call within the Jenkinsfile to ensure the Jenkins pipeline utilises the correct function.