### PR TITLE
Use sbt with postgres task.

### DIFF
--- a/vars/lambdaTests.groovy
+++ b/vars/lambdaTests.groovy
@@ -27,6 +27,7 @@ def call(Map config) {
         agent {
           ecs {
             inheritFrom "transfer-frontend"
+            taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
           }
         }
         steps {


### PR DESCRIPTION
I have created a lambda to create the database users and there are tests in the project which need to run against a postgres database. They can't be run against h2 because the syntax for creating users is different.
We already have a task definition which spins up a container with sbt and a container with postgres for the database publish task. I've renamed it and added it into the task definition here.
This does mean that we'll be spinning up two containers each time the lambda tests run but we're running these so rarely, this isn't going to cost too much.
