### PR TITLE
Add beforeAgent parameter

### DIFF
--- a/vars/lambdaTests.groovy
+++ b/vars/lambdaTests.groovy
@@ -45,7 +45,7 @@ def call(Map config) {
         }
 
         when {
-          beforeAgent: true
+          beforeAgent true
           expression { ["main", "master"].contains(env.BRANCH_NAME) }
         }
 

--- a/vars/lambdaTests.groovy
+++ b/vars/lambdaTests.groovy
@@ -45,6 +45,7 @@ def call(Map config) {
         }
 
         when {
+          beforeAgent: true
           expression { ["main", "master"].contains(env.BRANCH_NAME) }
         }
 


### PR DESCRIPTION
This change stop Jenkins starting the new container in ECS and then evaluating the branch condition. This will help with a current problem we're having with the notifications build but it will also help more generally in that we're not spinning up an ECS task just to abandon it because it's not building on the master branch.
We should update all conditional stages in other projects to use this at some point, it will speed up the builds as well as we're not waiting for the final task to start.