### PR TITLE
Run end-to-end tests after deploying Terraform jobs to staging

### DIFF
--- a/vars/terraformDeployJob.groovy
+++ b/vars/terraformDeployJob.groovy
@@ -99,7 +99,7 @@ def call(Map config) {
       }
       success {
         script {
-          if (config.stage == "intg") {
+          if (config.stage == "intg" || config.stage == "staging") {
             int delaySeconds = config.testDelaySeconds
 
             tdr.runEndToEndTests(delaySeconds, config.stage, BUILD_URL)


### PR DESCRIPTION
This condition was originally written when only integration had end-to-end tests, but now staging does as well.