### PR TITLE
Add param specifying Terraform node

### DIFF
--- a/vars/terraformCheckJob.groovy
+++ b/vars/terraformCheckJob.groovy
@@ -1,5 +1,8 @@
 def call(Map config) {
   library("tdr-jenkinslib")
+  
+  def terraformNode = config.containsKey("terraformNode") ? config.terraformNode : "terraform"
+  
   pipeline {
     agent {
       label "master"
@@ -15,7 +18,7 @@ def call(Map config) {
       stage('Check Terraform') {
         agent {
           ecs {
-            inheritFrom 'terraform'
+            inheritFrom "${terraformNode}"
           }
         }
         environment {

--- a/vars/terraformDeployJob.groovy
+++ b/vars/terraformDeployJob.groovy
@@ -1,6 +1,9 @@
 def call(Map config) {
   library("tdr-jenkinslib")
+
   def terraformWorkspace = config.stage == "mgmt" ? "default" : config.stage
+  def terraformNode = config.containsKey("terraformNode") ? config.terraformNode : "terraform"
+
   pipeline {
     agent {
       label "master"
@@ -21,7 +24,7 @@ def call(Map config) {
       stage('Run Terraform build') {
         agent {
           ecs {
-            inheritFrom 'terraform'
+            inheritFrom "${terraformNode}"
               taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/${config.taskRoleName}"
           }
         }


### PR DESCRIPTION
To support upgrade of Terraform versions require Terraform to be run on different nodes, with different versions of Terraform installed

Default to the standard Terraform node, if no terraformNode defined in the config map