### PR TITLE
Checkout 'tdr-terraform-module' branch for for v13

### DIFF
--- a/vars/terraformDeployJob.groovy
+++ b/vars/terraformDeployJob.groovy
@@ -3,6 +3,7 @@ def call(Map config) {
 
   def terraformWorkspace = config.stage == "mgmt" ? "default" : config.stage
   def terraformNode = config.containsKey("terraformNode") ? config.terraformNode : "terraform"
+  def terraformModulesBranch = config.containsKey("terraformNode") ? config.terraformNode : "master"
 
   pipeline {
     agent {
@@ -39,7 +40,7 @@ def call(Map config) {
             steps {
               dir("${config.terraformDirectoryPath}") {
                 echo 'Initializing Terraform...'
-                sh "git clone https://github.com/nationalarchives/tdr-terraform-modules.git"
+                sh "git clone --branch ${terraformModulesBranch} https://github.com/nationalarchives/tdr-terraform-modules.git"
                 sshagent(['github-jenkins']) {
                   sh("git clone git@github.com:nationalarchives/tdr-configurations.git")
                 }


### PR DESCRIPTION
In order to maintain backwards compatibility for those terraform repos that still use v12 and access the tdr-terraform-module repo maintain a branch in the tdr-terraform-module repo that is v13 compatible.

The v13 branch can then be used by those terraform repos that have been upgraded.

Once all terraform repos upgraded to v13 then the v13 branch can be merged into master and these changes reverted