### PR TITLE
Use build url instead of constructing it.

### DIFF
--- a/vars/terraformDeployJob.groovy
+++ b/vars/terraformDeployJob.groovy
@@ -59,8 +59,7 @@ def call(Map config) {
                 script {
                   tdr.postToDaTdrSlackChannel(colour: "good",
                     message: "Terraform plan complete for ${config.stage} TDR ${config.deployment}. " +
-                      "View here for plan: https://jenkins.tdr-management.nationalarchives.gov.uk/job/" +
-                      "${JOB_NAME.replaceAll(' ', '%20')}/${BUILD_NUMBER}/console"
+                        "${env.BUILD_URL}console"
                   )
                 }
               }
@@ -72,8 +71,7 @@ def call(Map config) {
               script {
                 tdr.postToDaTdrSlackChannel(colour: "good",
                   message: "Do you approve Terraform deployment for ${config.stage} TDR ${config.deployment}? " +
-                    "https://jenkins.tdr-management.nationalarchives.gov.uk/job/" +
-                    "${JOB_NAME.replaceAll(' ', '%20')}/${BUILD_NUMBER}/input/"
+                    "${env.BUILD_URL}input"
                 )
               }
               input "Do you approve deployment to ${config.stage}?"


### PR DESCRIPTION
The Jenkins url is hard coded but we have two Jenkins servers now so
this uses the BUILD url.
