### PR TITLE
Remove specification of master node from sub steps

### DIFF
--- a/vars/terraformCheckJob.groovy
+++ b/vars/terraformCheckJob.groovy
@@ -46,17 +46,13 @@ def call(Map config) {
         deleteDir()
       }
       failure {
-        node('master') {
-          script {
-            tdr.reportFailedBuildToGitHub(config.repo, env.GIT_COMMIT)
-          }
+        script {
+          tdr.reportFailedBuildToGitHub(config.repo, env.GIT_COMMIT)
         }
       }
       success {
-        node('master') {
-          script {
-            tdr.reportSuccessfulBuildToGitHub(config.repo, env.GIT_COMMIT)
-          }
+        script {
+          tdr.reportSuccessfulBuildToGitHub(config.repo, env.GIT_COMMIT)
         }
       }
     }


### PR DESCRIPTION
Specify the 'master' node in sub-steps of the build when the 'master' node is the default executor can cause deadlocks