### PR TITLE
Replace task definition name

### DIFF
--- a/vars/sbtReleaseDeployJob.groovy
+++ b/vars/sbtReleaseDeployJob.groovy
@@ -23,7 +23,7 @@ def call(Map config) {
         agent {
           ecs {
             inheritFrom "base"
-            taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish"
+            taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
           }
         }
         when {


### PR DESCRIPTION
The task name was changed a while ago to sbtwithpostgres.

The image hasn't been updated since then so we've not had any problems
but it has now so we need to change it to the image that's being managed
in terraform.
