### PR TITLE
TDR-850 Fix Jenkins insecure handling of GitHub token

### DIFF
--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -28,7 +28,7 @@ def runGitSecrets(repo) {
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
 def reportStartOfBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + '-H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + "--data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'")
+    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + ' -H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + " --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'")
   }
 }
 

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -28,7 +28,7 @@ def runGitSecrets(repo) {
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
 def reportStartOfBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'"
+    sh('curl -XPOST "${githubApiStatusUrl(repo, sha)}" -H "Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}" --data \'{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}\'')
   }
 }
 
@@ -36,14 +36,14 @@ def reportStartOfBuildToGitHub(String repo, String sha) {
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
 def reportSuccessfulBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'"
+    sh('curl -XPOST "${githubApiStatusUrl(repo, sha)}" -H "Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}" --data \'{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}\'')
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
 def reportFailedBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh "curl -XPOST '${githubApiStatusUrl(repo, sha)}' -H 'Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}' --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'"
+    sh('curl -XPOST "${githubApiStatusUrl(repo, sha)}" -H "Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}" --data \'{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}\'')
   }
 }
 

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -36,14 +36,14 @@ def reportStartOfBuildToGitHub(String repo, String sha) {
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
 def reportSuccessfulBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + '-H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + "--data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'")
+    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + ' -H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + " --data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'")
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
 def reportFailedBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + '-H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + "--data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'")
+    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + ' -H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + " --data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'")
   }
 }
 

--- a/vars/tdr.groovy
+++ b/vars/tdr.groovy
@@ -28,7 +28,7 @@ def runGitSecrets(repo) {
 // Call this when build starts (to let person who made changes know they are being checked) - call within first 'stage' of Jenkins pipeline actions.
 def reportStartOfBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh('curl -XPOST "${githubApiStatusUrl(repo, sha)}" -H "Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}" --data \'{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}\'')
+    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + '-H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + "--data '{\"state\":\"pending\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has started\",\"context\":\"TDR Jenkins build status\"}'")
   }
 }
 
@@ -36,14 +36,14 @@ def reportStartOfBuildToGitHub(String repo, String sha) {
 // Call when build finishes successfully - in Jenkins pipeline 'post' actions
 def reportSuccessfulBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh('curl -XPOST "${githubApiStatusUrl(repo, sha)}" -H "Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}" --data \'{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}\'')
+    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + '-H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + "--data '{\"state\":\"success\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has completed successfully\",\"context\":\"TDR Jenkins build status\"}'")
   }
 }
 
 // Call when build fails - in Jenkins pipeline 'post' actions
 def reportFailedBuildToGitHub(String repo, String sha) {
   withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_ACCESS_TOKEN')]) {
-    sh('curl -XPOST "${githubApiStatusUrl(repo, sha)}" -H "Authorization: bearer ${env.GITHUB_ACCESS_TOKEN}" --data \'{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}\'')
+    sh("curl -XPOST '${githubApiStatusUrl(repo, sha)}'" + '-H "Authorization: bearer $GITHUB_ACCESS_TOKEN" ' + "--data '{\"state\":\"failure\",\"target_url\":\"${env.BUILD_URL}\",\"description\":\"Jenkins build has failed\",\"context\":\"TDR Jenkins build status\"}'")
   }
 }
 


### PR DESCRIPTION
This uses the single quote string interpolation for the secret $GITHUB_ACCESS_TOKEN as it says to here https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation but the single quote interpolation doesn't work with the github url or the build url so these are in double quoted strings and are concatenated to make the full shell command.
The Jenkins warning about insecure handling of the secret has gone away.

